### PR TITLE
Automated command usage

### DIFF
--- a/src/main/java/ru/redenergy/flexy/CommandBackend.java
+++ b/src/main/java/ru/redenergy/flexy/CommandBackend.java
@@ -1,12 +1,15 @@
 package ru.redenergy.flexy;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
+import com.google.common.collect.Iterables;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.text.TextComponentBase;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
+import net.minecraft.util.text.event.ClickEvent;
 import ru.redenergy.flexy.annotation.Arg;
 import ru.redenergy.flexy.annotation.Command;
 import ru.redenergy.flexy.annotation.Flag;
@@ -37,6 +40,29 @@ public class CommandBackend {
     public CommandBackend(FlexyCommand command) {
         this.command = command;
         collectCommands();
+    }
+
+    public void displayUsage(ICommandSender sender){
+        for(CommandConfiguration config: configs){
+            Command command = config.getCommandMethod().getAnnotation(Command.class);
+            if(!command.displayable()) continue;
+            String view = "/" + this.command.getCommandName() + " " + command.value().replace("{", "<").replace("}", ">") + " ";
+            StringBuilder options = new StringBuilder();
+            if(!config.getAvailableFlags().isEmpty()){
+                for(String flag: config.getAvailableFlags())
+                    options.append("[").append(flag).append("]").append(" ");
+                options.append(" ");
+            }
+            if(!config.getAvailableParameters().isEmpty()){
+                for (String par: config.getAvailableParameters())
+                    options.append("[").append(par).append(" ").append("<v>").append("]").append(" ");
+                options.append(" ");
+            }
+            String output = view + options.toString();
+            TextComponentTranslation textcomponenttranslation = new TextComponentTranslation(output);
+            textcomponenttranslation.getChatStyle().setChatClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/" + this.command.getCommandName() + " "));
+            sender.addChatMessage(textcomponenttranslation);
+        }
     }
 
     /**

--- a/src/main/java/ru/redenergy/flexy/CommandBackend.java
+++ b/src/main/java/ru/redenergy/flexy/CommandBackend.java
@@ -45,7 +45,7 @@ public class CommandBackend {
     public void displayUsage(ICommandSender sender){
         for(CommandConfiguration config: configs){
             Command command = config.getCommandMethod().getAnnotation(Command.class);
-            if(!command.displayable()) continue;
+            if(!command.displayable() || !hasPermission(command, sender)) continue;
             String view = "/" + this.command.getCommandName() + " " + command.value().replace("{", "<").replace("}", ">") + " ";
             StringBuilder options = new StringBuilder()
                     .append(getDisplayableFlags(config))

--- a/src/main/java/ru/redenergy/flexy/CommandBackend.java
+++ b/src/main/java/ru/redenergy/flexy/CommandBackend.java
@@ -47,22 +47,34 @@ public class CommandBackend {
             Command command = config.getCommandMethod().getAnnotation(Command.class);
             if(!command.displayable()) continue;
             String view = "/" + this.command.getCommandName() + " " + command.value().replace("{", "<").replace("}", ">") + " ";
-            StringBuilder options = new StringBuilder();
-            if(!config.getAvailableFlags().isEmpty()){
-                for(String flag: config.getAvailableFlags())
-                    options.append("[").append(flag).append("]").append(" ");
-                options.append(" ");
-            }
-            if(!config.getAvailableParameters().isEmpty()){
-                for (String par: config.getAvailableParameters())
-                    options.append("[").append(par).append(" ").append("<v>").append("]").append(" ");
-                options.append(" ");
-            }
+            StringBuilder options = new StringBuilder()
+                    .append(getDisplayableFlags(config))
+                    .append(getDisplayableParameters(config));
             String output = view + options.toString();
             TextComponentTranslation textcomponenttranslation = new TextComponentTranslation(output);
             textcomponenttranslation.getChatStyle().setChatClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/" + this.command.getCommandName() + " "));
             sender.addChatMessage(textcomponenttranslation);
         }
+    }
+
+    private StringBuilder getDisplayableFlags(CommandConfiguration config){
+        StringBuilder flags = new StringBuilder();
+        if(!config.getAvailableFlags().isEmpty()){
+            for(String flag: config.getAvailableFlags())
+                flags.append("[").append(flag).append("]").append(" ");
+            flags.append(" ");
+        }
+        return flags;
+    }
+
+    private StringBuilder getDisplayableParameters(CommandConfiguration config){
+        StringBuilder parameters = new StringBuilder();
+        if(!config.getAvailableParameters().isEmpty()){
+            for (String par: config.getAvailableParameters())
+                parameters.append("[").append(par).append(" ").append("<v>").append("]").append(" ");
+            parameters.append(" ");
+        }
+        return parameters;
     }
 
     /**

--- a/src/main/java/ru/redenergy/flexy/FlexyCommand.java
+++ b/src/main/java/ru/redenergy/flexy/FlexyCommand.java
@@ -16,6 +16,12 @@ public abstract class FlexyCommand extends CommandBase {
     private final CommandBackend backend = new CommandBackend(this);
 
     @Override
+    public String getCommandUsage(ICommandSender sender) {
+        backend.displayUsage(sender);
+        return null; //will cause non-critical NPE on client side but it's the only way to do it without patching
+    }
+
+    @Override
     public void execute(MinecraftServer server, ICommandSender sender, String[] args) {
         try {
             backend.resolveExecute(sender, args);

--- a/src/main/java/ru/redenergy/flexy/annotation/Command.java
+++ b/src/main/java/ru/redenergy/flexy/annotation/Command.java
@@ -20,4 +20,7 @@ public @interface Command {
 
     /** if command disabled it will not be collected */
     boolean disabled() default false;
+
+    /** whether or not this command should be displayed in /help output */
+    boolean displayable() default true;
 }

--- a/src/main/java/ru/redenergy/flexy/resolve/TemplateResolver.java
+++ b/src/main/java/ru/redenergy/flexy/resolve/TemplateResolver.java
@@ -72,6 +72,8 @@ public class TemplateResolver {
         if(!possiblePars.isEmpty())
             for(String par: possiblePars) {
                 int parIndex = args.indexOf(par);
+                if(parIndex == -1)
+                    continue;
                 if (parIndex >= 0 && parIndex + 1 < args.size()){
                     String val = args.remove(parIndex + 1);
                     args.remove(parIndex);


### PR DESCRIPTION
This PR allows command usage output (the one which is used in /help command) to be automatically generated based on your declared commands. Generated syntax looks like this: 
`/<command name> <arguments in angle brackets> <flags in square brackets> <parameters in square brackets`
Example:
Assuming you have such command:

```
@Override
public String getCommandName(){ return "item"; } 

@Command("give <user> <item>")
void cmd(@Arg("user") String user, @Flag("-a") boolean flag, @Par("--p") Optional par){
     //logic...
}
```

Such command usage will be generated:
`/item give <user> <item> [-a] [--p <v>]`
